### PR TITLE
Update slider.js

### DIFF
--- a/src/js/slider.js
+++ b/src/js/slider.js
@@ -15,15 +15,17 @@
   Slider.prototype.bind = function () {
     this.container
       .on($.touchEvents.start, $.proxy(this.touchStart, this))
+      .on($.touchEvents.move, $.proxy(this.touchMove, this))
       .on($.touchEvents.end, $.proxy(this.touchEnd, this));
-    $(document.body).on($.touchEvents.move, $.proxy(this.touchMove, this)) // move even outside container
+    
   }
 
   Slider.prototype.touchStart = function (e) {
     e.preventDefault()
     this.start = $.getTouchPosition(e)
     this.width = this.container.find('.weui-slider__inner').width()
-    this.left = parseInt(this.container.find('.weui-slider__handler').css('left'))
+    var per = parseInt(this.container.find('.weui-slider__handler').css('left') ) 
+    this.left = this.width * per /100;
     this.touching = true
   }
 


### PR DESCRIPTION
1. 返回上一次更新, 还是将 触屏事件限制到 containner内部, 否则这个页面无法滑动了
this.container.on($.touchEvents.move, $.proxy(this.touchMove, this))
    // $(document.body).on($.touchEvents.move, $.proxy(this.touchMove, this)) // move even outside container

2. 当slider有初始化值, 比如30% 的时候, 我尝试设置weui-slider__track 和 weui-slider__handler 还有weui-slider-box__value, 然后发现bug发生在 : this.left = parseInt(this.container.find('.weui-slider__handler').css('left')),  css里面的值是 百分比, left 没有乘以width 导致异常, 修改为:
var per = parseInt(this.container.find('.weui-slider__handler').css('left') ) 
this.left = this.width * per /100;